### PR TITLE
VitalStatsのfetchをインフラ層に分離

### DIFF
--- a/src/entities/vitalStats.ts
+++ b/src/entities/vitalStats.ts
@@ -1,0 +1,14 @@
+export type VitalStats = {
+  iso3: string;
+  births: number;
+  deaths: number;
+  lat: number;
+  lon: number;
+};
+
+export type VitalStatsFromSupabase = {
+  iso3: string;
+  births: number;
+  deaths: number;
+  countries: { lat: number; lon: number } | null;
+};

--- a/src/infrastructures/vitalStatsOparations.ts
+++ b/src/infrastructures/vitalStatsOparations.ts
@@ -1,0 +1,47 @@
+import { VitalStats, VitalStatsFromSupabase } from "@/entities/vitalStats";
+import { supabase } from "@/lib/supabase";
+
+export const fetchVitalStatsByYearOperation = async (
+  year: number
+): Promise<Array<VitalStats>> => {
+  const { data, error } = await supabase
+    .from("vital_stats")
+    .select(
+      `
+          iso3, births, deaths,
+          countries:iso3(lat,lon)
+        `
+    )
+    .eq("year", year)
+    /* 
+    NOTE: 型推論が合わない！？ 
+      ×　contries:{lat:number,lon:number}
+      ○　countries:Array<{lat:number,lon:number}>
+      ではないか説
+    */
+    .returns<Array<VitalStatsFromSupabase>>();
+
+  if (error) throw error;
+  if (!data?.length) return [];
+
+  const vitalStats: Array<VitalStats> = data
+    .filter(
+      (
+        record
+      ): record is VitalStatsFromSupabase & {
+        countries: { lat: number; lon: number };
+      } => record.countries !== null
+    )
+    .map(
+      (record) =>
+        ({
+          iso3: record.iso3,
+          births: record.births,
+          deaths: record.deaths,
+          lat: record.countries.lat,
+          lon: record.countries.lon,
+        } as VitalStats)
+    );
+
+  return vitalStats;
+};


### PR DESCRIPTION
## 概要
threeModel.tsx内のVitalStatsのfetchをインフラ層に分離しました。

## 変更内容
- VitalStats系のtypeをentitieに切り出し
- インフラ層に取得関数を切り出し

単純なCRUD操作は
~Operationといった形で関数切り出ししています。